### PR TITLE
Update InscriptionId methods

### DIFF
--- a/src/inscription_id.rs
+++ b/src/inscription_id.rs
@@ -44,6 +44,15 @@ impl InscriptionId {
         let (txid, vout) = self.outpoint.decode();
         format!("{}i{}", txid, vout)
     }
+
+    pub fn new(txid: String, vout: u32) -> Result<InscriptionId> {
+        let outpoint = Outpoint::new(txid, vout)?;
+        Ok(InscriptionId { outpoint })
+    }
+
+    pub fn decode(&self) -> (String, u32) {
+        self.outpoint.decode()
+    }
 }
 
 impl<'de> Deserialize<'de> for InscriptionId {
@@ -105,8 +114,6 @@ impl FromStr for InscriptionId {
             Err(e) => anyhow::bail!("{} invalid vout: {}", s, e),
         };
 
-        let outpoint = Outpoint::new(format!("{}", txid), vout).unwrap();
-
-        Ok(InscriptionId::from_bytes(outpoint.to_bytes()))
+        InscriptionId::new(format!("{}", txid), vout)
     }
 }


### PR DESCRIPTION
Add new methods and update existing method in `src/inscription_id.rs`.

* Add `InscriptionId::new` method to create an `InscriptionId` from `Outpoint`.
* Add `InscriptionId::decode` method to decode `InscriptionId` into `Txid` and `vout`.
* Update `InscriptionId::from_str` to use `InscriptionId::new` and `InscriptionId::decode`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/unisat-wallet/ordinals-collections?shareId=XXXX-XXXX-XXXX-XXXX).